### PR TITLE
Updated to support latest python-adb API

### DIFF
--- a/aboot.py
+++ b/aboot.py
@@ -72,7 +72,8 @@ def all():
 class ABOOT(Serializable):
     @classmethod
     def create_from_json(cls, path):
-        data = json.load(file(path, "rb"))
+        with open(path, "rb") as fh:
+            data = json.load(fh)
         return ABOOT().set_data(data)
 
     @classmethod

--- a/config.py
+++ b/config.py
@@ -41,9 +41,11 @@ class Config(Serializable):
         global config
         if not config:
             config = Config()
-            config.set_data(json.load(file(DATA_PATH, "rb")))
+            with open(DATA_PATH, "rb") as fh:
+                config.set_data(json.load(fh))
 
-            data = "[root]\n"+file(USER_CONFIG_PATH, "rb").read()
+            with open(USER_CONFIG_PATH, "rb") as fh:
+                data = "[root]\n"+fh.read()
             fp = io.BytesIO(data)
             parser = ConfigParser.RawConfigParser()
             parser.readfp(fp)

--- a/config.py
+++ b/config.py
@@ -52,19 +52,19 @@ class Config(Serializable):
             for k in parser.options("root"):
                 try:
                     cfg[k] = parser.getboolean("root", k)
-                    continue;
+                    continue
                 except ValueError:
                     pass
 
                 try:
                     cfg[k] = parser.getint("root", k)
-                    continue;
+                    continue
                 except ValueError:
                     pass
 
                 try:
                     cfg[k] = parser.getfloat("root", k)
-                    continue;
+                    continue
                 except ValueError:
                     pass
 

--- a/image.py
+++ b/image.py
@@ -28,7 +28,10 @@ def add(path):
         for root,dirs,files in os.walk(path):
             for f in files:
                 T(f)
-                add_image(os.path.join(root, f))
+                if add_image(os.path.join(root, f)):
+                    print("Added: {}".format(f))
+                else:
+                    print("Skipped: {}".format(f))
 
 
 def add_image(path):
@@ -78,7 +81,7 @@ def add_aboot(archive):
     if bl.save('%s/%s-%s-%s.json' % (Config.data_path, bl.oem, bl.device, bl.build)):
         skipped = ""
 
-    I("%s (%d) %s" % (bl, len(bl.strings), skipped))
+    I("%s (%d) %s SAVING" % (bl, len(bl.strings), skipped))
     return bl
 
 


### PR DESCRIPTION
python-adb changed how an external caller interacts with the FastbootCommands and AdbCommands classes. Updated abootool to support this. Also allowed for timeouts in FastbootCommands.ConnectDevice() that throws an exception.